### PR TITLE
fix button classes in revert modal

### DIFF
--- a/resources/views/buttons/revert.blade.php
+++ b/resources/views/buttons/revert.blade.php
@@ -27,8 +27,22 @@
                 title: trans.warning,
                 text: trans.revert_confirm,
                 icon: 'warning',
-                buttons: [trans.cancel, trans.revert],
-                dangerMode: true,
+                buttons: {
+		  	cancel: {
+				text: trans.cancel,
+				value: null,
+				visible: true,
+				className: "bg-secondary",
+				closeModal: true,
+			},
+			delete: {
+				text: trans.revert,
+				value: true,
+				visible: true,
+				className: "bg-danger",
+				},
+			},
+		    dangerMode: true,
             }).then((value) => {
                 if (! value) return;
                 


### PR DESCRIPTION
As reported in https://github.com/Laravel-Backpack/translation-manager/issues/13

After @promatik started working on this package, we did some updates to our buttons across all packages to add specific classes that make them look good in all theme variants. 

We didn't propagate those changes here, so I am doing it now. 