### PR TITLE
change badge to be compatible with all themes

### DIFF
--- a/src/Http/Controllers/TranslationManagerCrudController.php
+++ b/src/Http/Controllers/TranslationManagerCrudController.php
@@ -55,7 +55,7 @@ class TranslationManagerCrudController extends CrudController
             'label' => ucfirst(__('backpack.translation-manager::translation_manager.key')),
             'type'  => 'custom_html',
             'value' => function (TranslationLine $entry): string {
-                return '<span class="badge" title="'.$entry->group_key.'">'.Str::limit($entry->group_key, 50).'</span>';
+                return '<span class="badge text-bg-secondary badge-primary" title="'.$entry->group_key.'">'.Str::limit($entry->group_key, 50).'</span>';
             },
             'orderable'  => true,
             'orderLogic' => function (Builder $query, mixed $column, mixed $columnDirection): Builder {


### PR DESCRIPTION
fixes #23 

This is a slight different badge color-theme wise, but it is a "sensible" default for all the themes. 