### PR TITLE
dont load namespaced translations

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -1,10 +1,6 @@
 <?php
 
 return [
-    // This will automatically load all translation paths registered by packages
-    // If you want to set the file paths manually, set this to false
-    'load_all_registered_translation_paths' => true,
-
     // Paths from where the language files are loaded
     // You can restrict the paths to a specific set
     // It's only applied if load_all_registered_translation_paths is set to false

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 Translation Manager provides a simple user interface to help you deal with translations in your Backpack application.
 At a quick glance, some of the most relevant features are:
 
-- View a list of all translations present in your application's language files (including vendor translations).
+- View a list of all translations present in your application's language files.
 - Edit translations directly from the interface.
 - Search and filter translations for easy management.
 
@@ -71,7 +71,7 @@ php artisan vendor:publish --provider="Backpack\TranslationManager\AddonServiceP
 
 ![lm_list_view2](https://github.com/Laravel-Backpack/language-manager/assets/1032474/f65a24ea-473d-4fec-8ffc-b8137bcb1b9f)
 
-The list view displays a comprehensive list of all translations within your application. By default, all translations including vendor translations are displayed in the list view. If you don't want to see vendor translations, you can set the config option `load_all_registered_translation_paths` to `false` in `config/backpack/translation-manager.php`.
+The list view displays a comprehensive list of all translations within your application translation folder (usually `lang/`). Please do note that translations in `lang/vendor/xxx` folders are not possible to translate using this package.
 
 Additionally, if you have [Backpack Pro](https://backpackforlaravel.com/products/pro-for-unlimited-projects) installed, your admin can also see and use the filters, to quickly narrow down translations.
 


### PR DESCRIPTION
Namespaced translations can't be translated using the spatie package. 😢 

For that reason the ability to load vendor lang files had been disabled. 
Any files inside the `lang/vendor/xxx` folders are also ignored, as that per laravel convention is where namespaced translations can be overwritten. 