### PR TITLE
ensure correct return types on model

### DIFF
--- a/src/Models/TranslationLine.php
+++ b/src/Models/TranslationLine.php
@@ -130,7 +130,7 @@ class TranslationLine extends TranslationLineOriginal
     /**
      * Boot the model.
      */
-    public static function boot()
+    public static function boot(): void
     {
         parent::boot();
 


### PR DESCRIPTION
Fixes: https://github.com/Laravel-Backpack/community-forum/discussions/1307

The return type of our overwrite was not the same of the parent spatie model. 